### PR TITLE
Improve chart rendering and validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,15 +157,20 @@
         const wb = XLSX.read(new Uint8Array(evt.target.result), {type:'array'});
         const sheet = wb.Sheets[wb.SheetNames[0]];
         const json = XLSX.utils.sheet_to_json(sheet);
-        trades = json.map(r => ({
-          date: r.Date,
-          asset: r.Asset,
-          type: r.Type,
-          entry: parseFloat(r.Entry),
-          exit: r.Exit === '' || r.Exit == null ? null : parseFloat(r.Exit),
-          quantity: parseFloat(r.Quantity),
-          reason: r.Reason || ''
-        }));
+        trades = json.map(r => {
+          const entryVal = parseFloat(r.Entry);
+          const exitRaw = r.Exit === '' || r.Exit == null ? null : parseFloat(r.Exit);
+          const qtyVal = parseFloat(r.Quantity);
+          return {
+            date: r.Date,
+            asset: r.Asset,
+            type: r.Type,
+            entry: isNaN(entryVal) ? 0 : entryVal,
+            exit: exitRaw === null || isNaN(exitRaw) ? null : exitRaw,
+            quantity: isNaN(qtyVal) ? 0 : qtyVal,
+            reason: r.Reason || ''
+          };
+        });
         localStorage.setItem(tradesKey, JSON.stringify(trades));
         render();
       };
@@ -258,21 +263,16 @@
     let chart;
     function renderChart(data) {
       const ctx = document.getElementById('capitalChart').getContext('2d');
-      if (chart) chart.destroy();
-      chart = new Chart(ctx, {
-        type: 'line',
-        data: {
-          labels: data.map(d => d.month),
-          datasets: [{
-            label: 'Capital',
-            data: data.map(d => d.value),
-            fill: false,
-            borderColor: 'rgb(75,192,192)',
-            tension: 0.1
-          }]
-        },
-        options: { responsive: true, maintainAspectRatio:false }
-      });
+      if (!chart) {
+        chart = new Chart(ctx, {
+          type: 'line',
+          data: { labels: [], datasets: [{ label: 'Capital', data: [], fill: false, borderColor: 'rgb(75,192,192)', tension: 0.1 }] },
+          options: { responsive: true, maintainAspectRatio:false, animation:false }
+        });
+      }
+      chart.data.labels = data.map(d => d.month);
+      chart.data.datasets[0].data = data.map(d => d.value);
+      chart.update();
     }
 
     function render(){


### PR DESCRIPTION
## Summary
- validate imported numeric fields to prevent NaN values
- reuse the Chart.js instance and disable animations for better performance

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a87a64990832b8cedda11e2c16f11